### PR TITLE
Switch to -full LTS version of ffmpeg-kit to mirror the Upgame plugin

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - ffmpeg-kit-ios-min (5.1)
-  - ffmpeg_kit_flutter_min (5.1.0):
-    - ffmpeg_kit_flutter_min/min (= 5.1.0)
+  - ffmpeg-kit-ios-full (5.1.LTS)
+  - ffmpeg_kit_flutter_full (5.1.0.LTS):
+    - ffmpeg_kit_flutter_full/full-lts (= 5.1.0.LTS)
     - Flutter
-  - ffmpeg_kit_flutter_min/min (5.1.0):
-    - ffmpeg-kit-ios-min (= 5.1)
+  - ffmpeg_kit_flutter_full/full-lts (5.1.0.LTS):
+    - ffmpeg-kit-ios-full (= 5.1.LTS)
     - Flutter
   - Flutter (1.0.0)
   - image_picker_ios (0.0.1):
@@ -28,7 +28,7 @@ PODS:
     - libwebp
 
 DEPENDENCIES:
-  - ffmpeg_kit_flutter_min (from `.symlinks/plugins/ffmpeg_kit_flutter_min/ios`)
+  - ffmpeg_kit_flutter_full (from `.symlinks/plugins/ffmpeg_kit_flutter_full/ios`)
   - Flutter (from `Flutter`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
@@ -37,12 +37,12 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - ffmpeg-kit-ios-min
+    - ffmpeg-kit-ios-full
     - libwebp
 
 EXTERNAL SOURCES:
-  ffmpeg_kit_flutter_min:
-    :path: ".symlinks/plugins/ffmpeg_kit_flutter_min/ios"
+  ffmpeg_kit_flutter_full:
+    :path: ".symlinks/plugins/ffmpeg_kit_flutter_full/ios"
   Flutter:
     :path: Flutter
   image_picker_ios:
@@ -55,8 +55,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/video_thumbnail/ios"
 
 SPEC CHECKSUMS:
-  ffmpeg-kit-ios-min: 3748f7726cd539e308090371a9d572d1a9dfaf7e
-  ffmpeg_kit_flutter_min: 03876cb5ff5f7cf493cbcef07fa738ae423e009c
+  ffmpeg-kit-ios-full: 700cfc7875827573940deb58d00fbc3c48701e42
+  ffmpeg_kit_flutter_full: 5665972767845dcd50b089e1054f858d15bc06b1
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
-import 'package:ffmpeg_kit_flutter_min/ffmpeg_kit.dart';
-import 'package:ffmpeg_kit_flutter_min/ffmpeg_kit_config.dart';
-import 'package:ffmpeg_kit_flutter_min/ffprobe_kit.dart';
-import 'package:ffmpeg_kit_flutter_min/return_code.dart';
-import 'package:ffmpeg_kit_flutter_min/statistics.dart';
+import 'package:ffmpeg_kit_flutter_full/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_full/ffmpeg_kit_config.dart';
+import 'package:ffmpeg_kit_flutter_full/ffprobe_kit.dart';
+import 'package:ffmpeg_kit_flutter_full/return_code.dart';
+import 'package:ffmpeg_kit_flutter_full/statistics.dart';
 import 'package:path/path.dart' as path;
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/entities/file_format.dart';
@@ -39,18 +39,7 @@ enum RotateDirection { left, right }
 /// you will achieve better quality with a slower preset.
 /// Similarly, for constant quality encoding,
 /// you will simply save bitrate by choosing a slower preset.
-enum VideoExportPreset {
-  none,
-  ultrafast,
-  superfast,
-  veryfast,
-  faster,
-  fast,
-  medium,
-  slow,
-  slower,
-  veryslow
-}
+enum VideoExportPreset { none, ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow }
 
 /// The default value of this property `Offset(1.0, 1.0)`
 const Offset _max = Offset(1.0, 1.0);
@@ -88,8 +77,7 @@ class VideoEditorController extends ChangeNotifier {
           Platform.isIOS ? Uri.encodeFull(file.path) : file.path,
         )),
         trimStyle = trimStyle ?? TrimSliderStyle(),
-        assert(maxDuration > minDuration,
-            'The maximum duration must be bigger than the minimum duration');
+        assert(maxDuration > minDuration, 'The maximum duration must be bigger than the minimum duration');
 
   int _rotation = 0;
   bool _isTrimming = false;
@@ -112,8 +100,7 @@ class VideoEditorController extends ChangeNotifier {
   final VideoPlayerController _video;
 
   // Selected cover value
-  final ValueNotifier<CoverData?> _selectedCover =
-      ValueNotifier<CoverData?>(null);
+  final ValueNotifier<CoverData?> _selectedCover = ValueNotifier<CoverData?>(null);
 
   /// Get the [VideoPlayerController]
   VideoPlayerController get video => _video;
@@ -204,10 +191,8 @@ class VideoEditorController extends ChangeNotifier {
         height: newSize.height,
       );
 
-      _minCrop =
-          Offset(centerCrop.left / videoWidth, centerCrop.top / videoHeight);
-      _maxCrop = Offset(
-          centerCrop.right / videoWidth, centerCrop.bottom / videoHeight);
+      _minCrop = Offset(centerCrop.left / videoWidth, centerCrop.top / videoHeight);
+      _maxCrop = Offset(centerCrop.right / videoWidth, centerCrop.bottom / videoHeight);
       notifyListeners();
     }
   }
@@ -246,8 +231,7 @@ class VideoEditorController extends ChangeNotifier {
 
     // Trim straight away when maxDuration is lower than video duration
     if (maxDuration < videoDuration) {
-      updateTrim(
-          0.0, maxDuration.inMilliseconds / videoDuration.inMilliseconds);
+      updateTrim(0.0, maxDuration.inMilliseconds / videoDuration.inMilliseconds);
     } else {
       _updateTrimRange();
     }
@@ -305,8 +289,7 @@ class VideoEditorController extends ChangeNotifier {
   ///
   /// Arguments range are [Offset.zero] to `Offset(1.0, 1.0)`.
   void updateCrop(Offset min, Offset max) {
-    assert(min < max,
-        'Minimum crop value ($min) cannot be bigger and maximum crop value ($max)');
+    assert(min < max, 'Minimum crop value ($min) cannot be bigger and maximum crop value ($max)');
 
     _minCrop = min;
     _maxCrop = max;
@@ -324,12 +307,10 @@ class VideoEditorController extends ChangeNotifier {
   ///
   /// Arguments range are `0.0` to `1.0`.
   void updateTrim(double min, double max) {
-    assert(min < max,
-        'Minimum trim value ($min) cannot be bigger and maximum trim value ($max)');
+    assert(min < max, 'Minimum trim value ($min) cannot be bigger and maximum trim value ($max)');
 
     // check that the new params does not cause a wrong duration
-    final newDuration = Duration(
-        milliseconds: (videoDuration.inMilliseconds * (max - min)).toInt());
+    final newDuration = Duration(milliseconds: (videoDuration.inMilliseconds * (max - min)).toInt());
     assert(newDuration <= maxDuration && newDuration >= minDuration,
         'Trim duration ($newDuration) cannot be bigger than $maxDuration or smaller than $minDuration');
 
@@ -388,8 +369,7 @@ class VideoEditorController extends ChangeNotifier {
   /// Get the [trimPosition], which is the videoPosition in the trim slider
   ///
   /// Range of the param is `0.0` to `1.0`.
-  double get trimPosition =>
-      videoPosition.inMilliseconds / videoDuration.inMilliseconds;
+  double get trimPosition => videoPosition.inMilliseconds / videoDuration.inMilliseconds;
 
   //-----------//
   //VIDEO COVER//
@@ -471,9 +451,7 @@ class VideoEditorController extends ChangeNotifier {
   //--------------//
 
   /// Return the metadata of the video [file] using Ffprobe
-  Future<void> getMetaData(
-      {required void Function(Map<dynamic, dynamic>? metadata)
-          onCompleted}) async {
+  Future<void> getMetaData({required void Function(Map<dynamic, dynamic>? metadata) onCompleted}) async {
     await FFprobeKit.getMediaInformationAsync(file.path, (session) async {
       final information = session.getMediaInformation();
       onCompleted(information?.getAllProperties());
@@ -491,8 +469,7 @@ class VideoEditorController extends ChangeNotifier {
     String? outputDirectory,
     required FileFormat format,
   }) async {
-    final String tempPath =
-        outputDirectory ?? (await getTemporaryDirectory()).path;
+    final String tempPath = outputDirectory ?? (await getTemporaryDirectory()).path;
     name ??= path.basenameWithoutExtension(filePath);
     final int epoch = DateTime.now().millisecondsSinceEpoch;
     return "$tempPath/${name}_$epoch.${format.extension}";
@@ -507,24 +484,18 @@ class VideoEditorController extends ChangeNotifier {
     if (!isFiltersEnabled) return "";
 
     // CALCULATE FILTERS
-    final bool isGif =
-        videoFormat?.extension == VideoExportFormat.gif.extension;
-    final String scaleInstruction =
-        scale == 1.0 ? "" : "scale=iw*$scale:ih*$scale";
+    final bool isGif = videoFormat?.extension == VideoExportFormat.gif.extension;
+    final String scaleInstruction = scale == 1.0 ? "" : "scale=iw*$scale:ih*$scale";
 
     // VALIDATE FILTERS
     final List<String> filters = [
       _getCrop(),
       scaleInstruction,
       _getRotation(),
-      isGif
-          ? "fps=${videoFormat is GifExportFormat ? videoFormat.fps : VideoExportFormat.gif.fps}"
-          : "",
+      isGif ? "fps=${videoFormat is GifExportFormat ? videoFormat.fps : VideoExportFormat.gif.fps}" : "",
     ];
     filters.removeWhere((item) => item.isEmpty);
-    return filters.isNotEmpty
-        ? "-vf '${filters.join(",")}'${isGif ? " -loop 0" : ""}"
-        : "";
+    return filters.isNotEmpty ? "-vf '${filters.join(",")}'${isGif ? " -loop 0" : ""}" : "";
   }
 
   /// Export the video using this edition parameters and return a `File`.
@@ -589,8 +560,7 @@ class VideoEditorController extends ChangeNotifier {
     FFmpegKit.executeAsync(
       execute,
       (session) async {
-        final state =
-            FFmpegKitConfig.sessionStateToString(await session.getState());
+        final state = FFmpegKitConfig.sessionStateToString(await session.getState());
         final code = await session.getReturnCode();
 
         if (ReturnCode.isSuccess(code)) {
@@ -598,8 +568,7 @@ class VideoEditorController extends ChangeNotifier {
         } else {
           if (onError != null) {
             onError(
-              Exception(
-                  'FFmpeg process exited with state $state and return code $code.\n${await session.getOutput()}'),
+              Exception('FFmpeg process exited with state $state and return code $code.\n${await session.getOutput()}'),
               StackTrace.current,
             );
           }
@@ -610,8 +579,7 @@ class VideoEditorController extends ChangeNotifier {
       onProgress != null
           ? (stats) {
               // Progress value of encoded video
-              double progressValue =
-                  stats.getTime() / trimmedDuration.inMilliseconds;
+              double progressValue = stats.getTime() / trimmedDuration.inMilliseconds;
               onProgress(stats, progressValue.clamp(0.0, 1.0));
             }
           : null,
@@ -724,8 +692,7 @@ class VideoEditorController extends ChangeNotifier {
       outputDirectory: outDir,
       format: format,
     );
-    final String filter =
-        _getExportFilters(scale: scale, isFiltersEnabled: isFiltersEnabled);
+    final String filter = _getExportFilters(scale: scale, isFiltersEnabled: isFiltersEnabled);
     // ignore: unnecessary_string_escapes
     final String execute = "-i \'$coverPath\' $filter -y $outputPath";
 
@@ -735,8 +702,7 @@ class VideoEditorController extends ChangeNotifier {
     FFmpegKit.executeAsync(
       execute,
       (session) async {
-        final state =
-            FFmpegKitConfig.sessionStateToString(await session.getState());
+        final state = FFmpegKitConfig.sessionStateToString(await session.getState());
         final code = await session.getReturnCode();
 
         if (ReturnCode.isSuccess(code)) {
@@ -744,8 +710,7 @@ class VideoEditorController extends ChangeNotifier {
         } else {
           if (onError != null) {
             onError(
-              Exception(
-                  'FFmpeg process exited with state $state and return code $code.\n${await session.getOutput()}'),
+              Exception('FFmpeg process exited with state $state and return code $code.\n${await session.getOutput()}'),
               StackTrace.current,
             );
           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  ffmpeg_kit_flutter_min: ^5.1.0
+  ffmpeg_kit_flutter_full: 5.1.0-LTS
   path: ^1.8.0 # update to `1.8.1` causes #79
   path_provider: ^2.0.12
   transparent_image: ^2.0.1 # show fade-in placeholder in thumbnails generation


### PR DESCRIPTION
The Android platform code of the Upgame Flutter plugin depends on ffmpeg-kit-full 5.1.0-LTS ([source](https://github.com/pgahq/video_analysis/blob/main/build.gradle#L80-L84)). This PR changes the dependency of video_editor to match.