### PR TITLE
update trim command

### DIFF
--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -584,7 +584,7 @@ class VideoEditorController extends ChangeNotifier {
       outputDirectory: outDir,
     );
     final trimCmd = "-ss $_trimStart -to $_trimEnd";
-    final String execute = ' -i ${file.path} $trimCmd -c copy $outputPath';
+    final String execute = ' $trimCmd -i ${file.path} -c copy $outputPath';
 
     debugPrint('VideoEditor - run export video command : [$execute]');
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1204688543353726/f

ffmpeg command previously followed the following format:

`ffmpeg -y -i <input_file> -ss HH:MM:SS -to HH:MM:SS -c copy <ouput_file>`

Which would produce an output video with black frames.

Changing the command to the format

`ffmpeg -y -ss HH:MM:SS -to HH:MM:SS -i <input_file> -c copy <ouput_file>`

Seems to successfully trim the video without introducing black frames at the beginning of the video.

It is unclear why this is the case.